### PR TITLE
Refactor failure reasons in interval to introduce report object

### DIFF
--- a/R/data_frame.R
+++ b/R/data_frame.R
@@ -84,19 +84,8 @@ is_data_frame <- function(df,
   return(TRUE)
 }
 assertthat::on_failure(is_data_frame) <- function(call, env) {
-  allow_na_msg <- ""
-  if (!is.null(call$allow_na)) {
-    if (eval(call$allow_na)) {
-      allow_na_msg <- " or NA"
-    }
-  }
-
-  allow_null_msg <- ""
-  if (!is.null(call$allow_null)) {
-    if (eval(call$allow_null)) {
-      allow_null_msg <- " or NULL"
-    }
-  }
+  allow_na <- callget(call, env, "allow_na", FALSE)
+  allow_null <- callget(call, env, "allow_null", FALSE)
 
   base_msg <- paste0(deparse(call$df), " must be a data frame")
   exact_colnames_msg <- NULL
@@ -148,8 +137,8 @@ assertthat::on_failure(is_data_frame) <- function(call, env) {
         required_rownames_msg,
         required_colnames_msg), collapse = " and"
       ),
-    allow_na_msg,
-    allow_null_msg,
+    snippet_na(allow_na),
+    snippet_null(allow_null),
     ". Got: ",
     paste0(deparse(eval(call$df, env)), collapse = ""))
   return(msg)

--- a/R/factor.R
+++ b/R/factor.R
@@ -46,31 +46,17 @@ is_factor <- function(
   return(TRUE)
 }
 assertthat::on_failure(is_factor) <- function(call, env) {
-  msg <- paste0(deparse(call$value), " must be a factor")
   exact_length <- callget(call, env, "exact_length", NULL)
   exact_levels <- callget(call, env, "exact_levels", NULL)
   allow_null <- callget(call, env, "allow_null", FALSE)
   allow_na_values <- callget(call, env, "allow_na_values", FALSE)
 
-  if (!is.null(exact_length)) {
-    msg <- paste0(msg, " of exact length ", eval(call$exact_length, env))
-  }
-
-  if (!is.null(exact_levels)) {
-    msg <- paste0(msg, " with exact levels ('",
-                  paste0(
-                    eval(call$exact_levels, env),
-                    collapse = "', '"
-                    ),
-                  "')"
-                  )
-  }
-  if (!allow_na_values) {
-    msg <- paste0(msg, " with no NAs")
-  }
-
   msg <- paste0(
-   msg,
+   deparse(call$value),
+   snippet_must_be("factor"),
+   snippet_length(exact_length),
+   snippet_exact_levels(exact_levels),
+   snippet_na_values(allow_na_values),
    ";",
    snippet_null(allow_null),
    ". Got: ",

--- a/R/factor.R
+++ b/R/factor.R
@@ -69,12 +69,10 @@ assertthat::on_failure(is_factor) <- function(call, env) {
     msg <- paste0(msg, " with no NAs")
   }
 
-  if (allow_null) {
-    msg <- paste0(msg, "; or NULL")
-  }
-
   msg <- paste0(
    msg,
+   ";",
+   snippet_null(allow_null),
    ". Got: ",
    deparse(eval(call$value, env))
   )

--- a/R/integers.R
+++ b/R/integers.R
@@ -49,25 +49,10 @@ assertthat::on_failure(is_integer_value) <- function(call, env) {
   min <- callget(call, env, "min", NULL)
   max <- callget(call, env, "max", NULL)
 
-  interval_msg <- ""
-  if (!is.null(min) || !is.null(max)) {
-    interval_msg <- " in the range "
-    if (is.null(min)) {
-      interval_msg <- paste0(interval_msg, "(-inf, ")
-    } else {
-      interval_msg <- paste0(interval_msg, "[", min, ", ")
-    }
-
-    if (is.null(max)) {
-      interval_msg <- paste0(interval_msg, "inf)")
-    } else {
-      interval_msg <- paste0(interval_msg, max, "]")
-    }
-  }
 
   return(paste0(deparse(call$value),
-                " must be an integer value",
-                interval_msg,
+                snippet_must_be("integer value"),
+                snippet_numerical_range(min, max),
                 snippet_null(allow_null),
                 ". Got: ",
                 deparse(eval(call$value, env))))
@@ -100,7 +85,7 @@ assertthat::on_failure(is_positive_integer_value) <- function(call, env) {
   return(
     paste0(
       deparse(call$value),
-      " must be a positive integer value",
+      snippet_must_be("positive integer value"),
       snippet_null(allow_null),
       ". Got: ",
       deparse(eval(call$value, env))
@@ -135,7 +120,7 @@ assertthat::on_failure(is_non_negative_integer_value) <- function(call, env) {
   return(
     paste0(
       deparse(call$value),
-      " must be a non negative integer value",
+      snippet_must_be("non negative integer value"),
       snippet_null(allow_null),
       ". Got: ",
       deparse(eval(call$value, env))
@@ -216,41 +201,11 @@ assertthat::on_failure(is_integer_vector) <- function(call, env) {
   allow_na_values <- callget(call, env, "allow_na_values", FALSE)
   allow_null <- callget(call, env, "allow_null", FALSE)
 
-  msg <- paste0(deparse(call$value),
-    " must be a vector of integer values")
-
-  if (!is.null(exact_length)) {
-    msg <- paste0(
-      msg,
-      " of exact length ", exact_length)
-  } else if (!is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length between ",
-      min_length,
-      " and ",
-      max_length,
-      " inclusive"
-    )
-  } else if (is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not greater than ",
-      max_length
-    )
-  } else if (!is.null(min_length) && is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not less than ",
-      min_length
-    )
-  }
-
-  if (!allow_na_values) {
-    msg <- paste0(msg, " with no NAs")
-  }
   msg <- paste0(
-    msg,
+    deparse(call$value),
+    snippet_must_be("vector of integer values"),
+    snippet_length(exact_length, min_length, max_length),
+    snippet_na_values(allow_na_values),
     snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))
@@ -323,43 +278,11 @@ assertthat::on_failure(is_positive_integer_vector) <- function(call, env) {
   max_length <- callget(call, env, "max_length", NULL)
   allow_na_values <- callget(call, env, "allow_na_values", FALSE)
 
-  msg <- paste0(deparse(call$value),
-    " must be a vector of positive integer values")
-
-  if (!is.null(exact_length)) {
-    msg <- paste0(
-      msg,
-      " of exact length ", exact_length
-    )
-  } else if (!is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length between ",
-      min_length,
-      " and ",
-      max_length,
-      " inclusive"
-    )
-  } else if (is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not greater than ",
-      max_length
-    )
-  } else if (!is.null(min_length) && is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not less than ",
-      min_length
-    )
-  }
-
-  if (!allow_na_values) {
-    msg <- paste0(msg, " with no NAs")
-  }
-
   msg <- paste0(
-    msg,
+    deparse(call$value),
+    snippet_must_be("vector of positive integer values"),
+    snippet_length(exact_length, min_length, max_length),
+    snippet_na_values(allow_na_values),
     ". Got: ",
     deparse(eval(call$value, env))
   )
@@ -432,42 +355,11 @@ assertthat::on_failure(is_non_negative_integer_vector) <- function(call, env) {
   max_length <- callget(call, env, "max_length", NULL)
   allow_na_values <- callget(call, env, "allow_na_values", FALSE)
 
-  msg <- paste0(deparse(call$value),
-    " must be a vector of non negative integer values")
-
-  if (!is.null(exact_length)) {
-    msg <- paste0(
-      msg,
-      " of exact length ", exact_length
-    )
-  } else if (!is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length between ",
-      min_length,
-      " and ",
-      max_length,
-      " inclusive"
-    )
-  } else if (is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not greater than ",
-      max_length
-    )
-  } else if (!is.null(min_length) && is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not less than ",
-      min_length
-    )
-  }
-
-  if (!allow_na_values) {
-    msg <- paste0(msg, " with no NAs")
-  }
   msg <- paste0(
-    msg,
+    deparse(call$value),
+    snippet_must_be("vector of non negative integer values"),
+    snippet_length(exact_length, min_length, max_length),
+    snippet_na_values(allow_na_values),
     ". Got: ",
     deparse(eval(call$value, env))
   )
@@ -520,22 +412,12 @@ assertthat::on_failure(is_binary_vector) <- function(call, env) {
   allow_na_values <- callget(call, env, "allow_na_values", FALSE)
   allow_degenerate <- callget(call, env, "allow_degenerate", TRUE)
 
-  na_msg <- ""
-  degenerate_msg <- ""
-  if (allow_na_values) {
-    na_msg <- " or NA"
-  }
-
-  if (!allow_degenerate) {
-    degenerate_msg <- " non-degenerate"
-  }
-
   return(
     paste0(
       deparse(call$v),
-      " must be a", degenerate_msg,
-      " vector of binary values (0 or 1",
-      na_msg, ")"
+      snippet_must_be("vector of binary values (0 or 1)"),
+      snippet_degenerate(allow_degenerate),
+      snippet_na_values(allow_na_values)
     )
   )
 }

--- a/R/integers.R
+++ b/R/integers.R
@@ -49,11 +49,6 @@ assertthat::on_failure(is_integer_value) <- function(call, env) {
   min <- callget(call, env, "min", NULL)
   max <- callget(call, env, "max", NULL)
 
-  allow_null_msg <- ""
-  if (allow_null) {
-    allow_null_msg <- " or NULL"
-  }
-
   interval_msg <- ""
   if (!is.null(min) || !is.null(max)) {
     interval_msg <- " in the range "
@@ -73,7 +68,7 @@ assertthat::on_failure(is_integer_value) <- function(call, env) {
   return(paste0(deparse(call$value),
                 " must be an integer value",
                 interval_msg,
-                allow_null_msg,
+                snippet_null(allow_null),
                 ". Got: ",
                 deparse(eval(call$value, env))))
 }
@@ -101,16 +96,12 @@ is_positive_integer_value <- function(value, allow_null = FALSE) {
 }
 assertthat::on_failure(is_positive_integer_value) <- function(call, env) {
   allow_null <- callget(call, env, "allow_null", FALSE)
-  allow_null_msg <- ""
-  if (allow_null) {
-    allow_null_msg <- " or NULL"
-  }
 
   return(
     paste0(
       deparse(call$value),
       " must be a positive integer value",
-      allow_null_msg,
+      snippet_null(allow_null),
       ". Got: ",
       deparse(eval(call$value, env))
     )
@@ -140,17 +131,12 @@ is_non_negative_integer_value <- function(value, allow_null = FALSE) {
 }
 assertthat::on_failure(is_non_negative_integer_value) <- function(call, env) {
   allow_null <- callget(call, env, "allow_null", FALSE)
-  allow_null_msg <- ""
-
-  if (allow_null) {
-    allow_null_msg <- " or NULL"
-  }
 
   return(
     paste0(
       deparse(call$value),
       " must be a non negative integer value",
-      allow_null_msg,
+      snippet_null(allow_null),
       ". Got: ",
       deparse(eval(call$value, env))
     )
@@ -263,11 +249,9 @@ assertthat::on_failure(is_integer_vector) <- function(call, env) {
   if (!allow_na_values) {
     msg <- paste0(msg, " with no NAs")
   }
-  if (allow_null) {
-    msg <- paste0(msg, " or NULL")
-  }
   msg <- paste0(
     msg,
+    snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))
   )

--- a/R/interval.R
+++ b/R/interval.R
@@ -39,29 +39,21 @@ assertthat::on_failure(is_interval) <- function(call, env) {
 }
 
 .inspect_interval <- function(low, high, allow_degenerate) {
-  res <- list(valid = FALSE, reason = "")
-
   if (!is_real_value(low)) {
-    res$reason <- "The low value must be a numeric value"
-    return(res)
+    return(failure("The low value must be a numeric value"))
   }
 
   if (!is_real_value(high)) {
-    res$reason <- "The high value must be a numeric value"
-    return(res)
+    return(failure("The high value must be a numeric value"))
   }
 
   if (low == high && !allow_degenerate) {
-    res$reason <- paste0(
-      "The low and high values are degenerate")
-    return(res)
+    return(failure("The low and high values are degenerate"))
   }
 
   if (low > high) {
-    res$reason <- "The low value cannot be higher than the high value"
-    return(res)
+    return(failure("The low value cannot be higher than the high value"))
   }
 
-  res$valid <- TRUE
-  return(res)
+  return(success())
 }

--- a/R/list.R
+++ b/R/list.R
@@ -69,11 +69,10 @@ assertthat::on_failure(is_list) <- function(call, env) {
                   "'"
                   )
   }
-  if (allow_null) {
-      msg <- paste0(msg, " or NULL")
-  }
+
   msg <- paste0(
    msg,
+   snippet_null(allow_null),
    ". Got: ",
    deparse(eval(call$l, env))
   )

--- a/R/list.R
+++ b/R/list.R
@@ -50,28 +50,15 @@ is_list <- function(
   return(TRUE)
 }
 assertthat::on_failure(is_list) <- function(call, env) {
-  msg <- paste0(deparse(call$l), " must be a list")
   required_names <- callget(call, env, "required_names", NULL)
   exact_length <- callget(call, env, "exact_length", NULL)
   allow_null <- callget(call, env, "allow_null", NULL)
 
-  if (!is.null(exact_length)) {
-    msg <- paste0(msg, " of exact length ", exact_length,
-                  " (passed ", length(eval(call$l, env)), ")")
-  }
-
-  if (!is.null(required_names)) {
-    msg <- paste0(msg, " with at least names '",
-                  paste0(
-                    required_names,
-                    collapse = "', '"
-                    ),
-                  "'"
-                  )
-  }
-
   msg <- paste0(
-   msg,
+   deparse(call$l),
+   snippet_must_be("list"),
+   snippet_length(exact_length),
+   snippet_names(required_names),
    snippet_null(allow_null),
    ". Got: ",
    deparse(eval(call$l, env))

--- a/R/logical.R
+++ b/R/logical.R
@@ -18,7 +18,8 @@ is_logical_value <- function(value) {
 assertthat::on_failure(is_logical_value) <- function(call, env) {
   return(paste0(
     deparse(call$value),
-    " must be a single logical value. Got: ",
+    snippet_must_be("logical value"),
+    ". Got: ",
     deparse(eval(call$value, env))
   ))
 }

--- a/R/obj-report.R
+++ b/R/obj-report.R
@@ -1,0 +1,19 @@
+failure <- function(reason) {
+  return(report(FALSE, reason))
+}
+
+success <- function() {
+  return(report(TRUE, NULL))
+}
+
+report <- function(valid, reason = NULL) {
+  return(
+    structure(
+      list(
+        valid = valid,
+        reason = reason
+      )
+    ),
+    class = "qscheck::report"
+  )
+}

--- a/R/r6.R
+++ b/R/r6.R
@@ -25,8 +25,7 @@ is_r6_class <- function(value, class_name) {
 assertthat::on_failure(is_r6_class) <- function(call, env) {
   msg <- paste0(
     deparse(call$value),
-    " must be an R6 class ",
-    call$class_name,
+    snippet_must_be(paste0("R6 class ", call$class_name)),
     ". Got: ",
     deparse(eval(call$value, env)))
   return(msg)
@@ -67,10 +66,10 @@ assertthat::on_failure(is_r6_instance) <- function(call, env) {
 
   msg <- paste0(
     deparse(call$value),
-    " must be an instance of R6 class ",
-    call$class_name,
+    snippet_must_be(paste0("instance of R6 class ", call$class_name)),
     snippet_null(allow_null),
     ". Got: ",
-    deparse(eval(call$value, env)))
+    deparse(eval(call$value, env))
+  )
   return(msg)
 }

--- a/R/r6.R
+++ b/R/r6.R
@@ -64,16 +64,12 @@ is_r6_instance <- function(value, class_name, allow_null = FALSE) {
 }
 assertthat::on_failure(is_r6_instance) <- function(call, env) {
   allow_null <- callget(call, env, "allow_null", FALSE)
-  allow_null_msg <- ""
-  if (allow_null) {
-    allow_null_msg <- " or NULL"
-  }
 
   msg <- paste0(
     deparse(call$value),
     " must be an instance of R6 class ",
     call$class_name,
-    allow_null_msg,
+    snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env)))
   return(msg)

--- a/R/real.R
+++ b/R/real.R
@@ -69,16 +69,6 @@ assertthat::on_failure(is_real_value) <- function(call, env) {
   allow_na <- callget(call, env, "allow_na", FALSE)
   allow_null <- callget(call, env, "allow_null", FALSE)
 
-  allow_na_msg <- ""
-  if (allow_na) {
-    allow_na_msg <- " or NA"
-  }
-
-  allow_null_msg <- ""
-  if (allow_null) {
-    allow_null_msg <- " or NULL"
-  }
-
   interval_msg <- ""
   if (!is.null(min) || !is.null(max)) {
     interval_msg <- " in the range "
@@ -103,8 +93,8 @@ assertthat::on_failure(is_real_value) <- function(call, env) {
   return(paste0(deparse(call$value),
                 " must be a single real value",
                 interval_msg,
-                allow_na_msg,
-                allow_null_msg,
+                snippet_na(allow_na),
+                snippet_null(allow_null),
                 ". Got: ",
                 deparse(eval(call$value, env))))
 }
@@ -135,20 +125,10 @@ assertthat::on_failure(is_positive_real_value) <- function(call, env) {
   allow_na <- callget(call, env, "allow_na", FALSE)
   allow_null <- callget(call, env, "allow_null", FALSE)
 
-  allow_na_msg <- ""
-  if (allow_na) {
-    allow_na_msg <- " or NA"
-  }
-
-  allow_null_msg <- ""
-  if (allow_null) {
-    allow_null_msg <- " or NULL"
-  }
-
   return(paste0(deparse(call$value),
                  " must be a positive real value",
-                 allow_na_msg,
-                 allow_null_msg,
+                 snippet_na(allow_na),
+                 snippet_null(allow_null),
                  ". Got: ",
                  deparse(eval(call$value, env))))
 }
@@ -174,13 +154,11 @@ is_probability_value <- function(value, allow_null = FALSE) {
 }
 assertthat::on_failure(is_probability_value) <- function(call, env) {
   allow_null <- callget(call, env, "allow_null", FALSE)
-  allow_null_msg <- ""
-  if (allow_null) {
-    allow_null_msg <- " or NULL"
-  }
+
   return(paste0(deparse(call$value),
                  " must be a single probability value in ",
-                 "the interval [0.0, 1.0]", allow_null_msg, ". Got: ",
+                 "the interval [0.0, 1.0]",
+                 snippet_null(allow_null), ". Got: ",
                  deparse(eval(call$value, env))))
 }
 
@@ -210,20 +188,10 @@ assertthat::on_failure(is_non_negative_real_value) <- function(call, env) {
   allow_na <- callget(call, env, "allow_na", FALSE)
   allow_null <- callget(call, env, "allow_null", FALSE)
 
-  allow_na_msg <- ""
-  if (allow_na) {
-    allow_na_msg <- " or NA"
-  }
-
-  allow_null_msg <- ""
-  if (allow_null) {
-    allow_null_msg <- " or NULL"
-  }
-
   return(paste0(deparse(call$value),
                  " must be a non-negative real value",
-                 allow_na_msg,
-                 allow_null_msg,
+                 snippet_na(allow_na),
+                 snippet_null(allow_null),
                  ". Got: ",
                  deparse(eval(call$value, env))))
 }
@@ -324,12 +292,9 @@ assertthat::on_failure(is_real_vector) <- function(call, env) {
     msg <- paste0(msg, " with no NAs")
   }
 
-  if (allow_null) {
-    msg <- paste0(msg, " or NULL")
-  }
-
   msg <- paste0(
     msg,
+    snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))
   )
@@ -441,12 +406,9 @@ assertthat::on_failure(is_positive_real_vector) <- function(call, env) {
     msg <- paste0(msg, " with no NAs")
   }
 
-  if (allow_null) {
-    msg <- paste0(msg, " or NULL")
-  }
-
   msg <- paste0(
     msg,
+    snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))
   )
@@ -557,12 +519,9 @@ assertthat::on_failure(is_non_negative_real_vector) <- function(call, env) {
     msg <- paste0(msg, " with no NAs")
   }
 
-  if (allow_null) {
-    msg <- paste0(msg, " or NULL")
-  }
-
   msg <- paste0(
     msg,
+    snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))
   )
@@ -674,12 +633,9 @@ assertthat::on_failure(is_probability_vector) <- function(call, env) {
     msg <- paste0(msg, " with no NAs")
   }
 
-  if (allow_null) {
-    msg <- paste0(msg, " or NULL")
-  }
-
   msg <- paste0(
     msg,
+    snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))
   )

--- a/R/real.R
+++ b/R/real.R
@@ -69,30 +69,10 @@ assertthat::on_failure(is_real_value) <- function(call, env) {
   allow_na <- callget(call, env, "allow_na", FALSE)
   allow_null <- callget(call, env, "allow_null", FALSE)
 
-  interval_msg <- ""
-  if (!is.null(min) || !is.null(max)) {
-    interval_msg <- " in the range "
-    if (is.null(min)) {
-      interval_msg <- paste0(interval_msg, "(-inf, ")
-    } else {
-      interval_msg <- paste0(
-        interval_msg,
-        ifelse(inclusive_min, "[", "("),
-        deparse(min), ", ")
-    }
-
-    if (is.null(max)) {
-      interval_msg <- paste0(interval_msg, "inf)")
-    } else {
-      interval_msg <- paste0(
-        interval_msg, deparse(max),
-        ifelse(inclusive_max, "]", ")"))
-    }
-  }
 
   return(paste0(deparse(call$value),
-                " must be a single real value",
-                interval_msg,
+                snippet_must_be("real value"),
+                snippet_numerical_range(min, max, inclusive_min, inclusive_max),
                 snippet_na(allow_na),
                 snippet_null(allow_null),
                 ". Got: ",
@@ -126,7 +106,7 @@ assertthat::on_failure(is_positive_real_value) <- function(call, env) {
   allow_null <- callget(call, env, "allow_null", FALSE)
 
   return(paste0(deparse(call$value),
-                 " must be a positive real value",
+                 snippet_must_be("positive real value"),
                  snippet_na(allow_na),
                  snippet_null(allow_null),
                  ". Got: ",
@@ -156,8 +136,9 @@ assertthat::on_failure(is_probability_value) <- function(call, env) {
   allow_null <- callget(call, env, "allow_null", FALSE)
 
   return(paste0(deparse(call$value),
-                 " must be a single probability value in ",
-                 "the interval [0.0, 1.0]",
+                 snippet_must_be(
+                  "probability value in the interval [0.0, 1.0]"
+                 ),
                  snippet_null(allow_null), ". Got: ",
                  deparse(eval(call$value, env))))
 }
@@ -189,7 +170,7 @@ assertthat::on_failure(is_non_negative_real_value) <- function(call, env) {
   allow_null <- callget(call, env, "allow_null", FALSE)
 
   return(paste0(deparse(call$value),
-                 " must be a non-negative real value",
+                 snippet_must_be("non-negative real value"),
                  snippet_na(allow_na),
                  snippet_null(allow_null),
                  ". Got: ",
@@ -254,46 +235,17 @@ is_real_vector <- function(
   return(TRUE)
 }
 assertthat::on_failure(is_real_vector) <- function(call, env) {
-  msg <- paste0(deparse(call$value), " must be a vector of real numbers")
   exact_length <- callget(call, env, "exact_length", NULL)
   min_length <- callget(call, env, "min_length", NULL)
   max_length <- callget(call, env, "max_length", NULL)
   allow_na_values <- callget(call, env, "allow_na_values", FALSE)
   allow_null <- callget(call, env, "allow_null", FALSE)
 
-  if (!is.null(exact_length)) {
-    msg <- paste0(
-      msg,
-      " of exact length ", exact_length
-    )
-  } else if (!is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length between ",
-      min_length,
-      " and ",
-      max_length,
-      " inclusive"
-    )
-  } else if (is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not greater than ",
-      max_length
-    )
-  } else if (!is.null(min_length) && is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not less than ",
-      min_length
-    )
-  }
-  if (!allow_na_values) {
-    msg <- paste0(msg, " with no NAs")
-  }
-
   msg <- paste0(
-    msg,
+    deparse(call$value),
+    snippet_must_be("vector of real numbers"),
+    snippet_length(exact_length, min_length, max_length),
+    snippet_na_values(allow_na_values),
     snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))
@@ -370,44 +322,12 @@ assertthat::on_failure(is_positive_real_vector) <- function(call, env) {
   max_length <- callget(call, env, "max_length", NULL)
   allow_na_values <- callget(call, env, "allow_na_values", FALSE)
   allow_null <- callget(call, env, "allow_null", FALSE)
+
   msg <- paste0(
     deparse(call$value),
-    " must be a vector of positive real numbers"
-  )
-
-  if (!is.null(exact_length)) {
-    msg <- paste0(
-      msg,
-      " of exact length ", exact_length
-    )
-  } else if (!is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length between ",
-      min_length,
-      " and ",
-      max_length,
-      " inclusive"
-    )
-  } else if (is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not greater than ",
-      max_length
-    )
-  } else if (!is.null(min_length) && is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not less than ",
-      min_length
-    )
-  }
-  if (!allow_na_values) {
-    msg <- paste0(msg, " with no NAs")
-  }
-
-  msg <- paste0(
-    msg,
+    snippet_must_be("vector of positive real numbers"),
+    snippet_length(exact_length, min_length, max_length),
+    snippet_na_values(allow_na_values),
     snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))
@@ -483,44 +403,12 @@ assertthat::on_failure(is_non_negative_real_vector) <- function(call, env) {
   max_length <- callget(call, env, "max_length", NULL)
   allow_na_values <- callget(call, env, "allow_na_values", FALSE)
   allow_null <- callget(call, env, "allow_null", FALSE)
+
   msg <- paste0(
     deparse(call$value),
-    " must be a vector of non-negative real numbers"
-  )
-
-  if (!is.null(exact_length)) {
-    msg <- paste0(
-      msg,
-      " of exact length ", exact_length
-    )
-  } else if (!is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length between ",
-      min_length,
-      " and ",
-      max_length,
-      " inclusive"
-    )
-  } else if (is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not greater than ",
-      max_length
-    )
-  } else if (!is.null(min_length) && is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not less than ",
-      min_length
-    )
-  }
-  if (!allow_na_values) {
-    msg <- paste0(msg, " with no NAs")
-  }
-
-  msg <- paste0(
-    msg,
+    snippet_must_be("vector of non-negative real numbers"),
+    snippet_length(exact_length, min_length, max_length),
+    snippet_na_values(allow_na_values),
     snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))
@@ -597,44 +485,12 @@ assertthat::on_failure(is_probability_vector) <- function(call, env) {
   max_length <- callget(call, env, "max_length", NULL)
   allow_na_values <- callget(call, env, "allow_na_values", FALSE)
   allow_null <- callget(call, env, "allow_null", FALSE)
+
   msg <- paste0(
     deparse(call$value),
-    " must be a vector of values in the interval [0.0, 1.0]"
-  )
-
-  if (!is.null(exact_length)) {
-    msg <- paste0(
-      msg,
-      " of exact length ", exact_length
-    )
-  } else if (!is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length between ",
-      min_length,
-      " and ",
-      max_length,
-      " inclusive"
-    )
-  } else if (is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not greater than ",
-      max_length
-    )
-  } else if (!is.null(min_length) && is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not less than ",
-      min_length
-    )
-  }
-  if (!allow_na_values) {
-    msg <- paste0(msg, " with no NAs")
-  }
-
-  msg <- paste0(
-    msg,
+    snippet_must_be("vector of values in the interval [0.0, 1.0]"),
+    snippet_length(exact_length, min_length, max_length),
+    snippet_na_values(allow_na_values),
     snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))
@@ -684,14 +540,10 @@ assertthat::on_failure(is_increasing_vector) <- function(call, env) {
     strictly_msg <- " strictly"
   }
 
-  allow_na_values_msg <- " with no NAs"
-  if (allow_na_values) {
-    allow_na_values_msg <- " or NAs"
-  }
-
   msg <- paste0(
-    deparse(call$v), " must be a vector of", strictly_msg,
-    " increasing numbers", allow_na_values_msg,
+    deparse(call$v),
+    snippet_must_be(paste0("vector of", strictly_msg, " increasing numbers")),
+    snippet_na_values(allow_na_values),
     ". Got: ",
     deparse(eval(call$v, env))
     )
@@ -741,14 +593,10 @@ assertthat::on_failure(is_decreasing_vector) <- function(call, env) {
     strictly_msg <- " strictly"
   }
 
-  allow_na_values_msg <- " with no NAs"
-  if (allow_na_values) {
-    allow_na_values_msg <- " or NAs"
-  }
-
   msg <- paste0(
-    deparse(call$v), " must be a vector of", strictly_msg,
-    " decreasing numbers", allow_na_values_msg,
+    deparse(call$v),
+    snippet_must_be(paste0("vector of", strictly_msg, " decreasing numbers")),
+    snippet_na_values(allow_na_values),
     ". Got: ",
     deparse(eval(call$v, env))
     )

--- a/R/s3.R
+++ b/R/s3.R
@@ -35,12 +35,9 @@ assertthat::on_failure(is_s3_instance) <- function(call, env) {
     call$class_name
     )
 
-  if (allow_null) {
-    msg <- paste0(msg, " or NULL")
-  }
-
   msg <- paste0(
     msg,
+    snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))
   )

--- a/R/s3.R
+++ b/R/s3.R
@@ -29,14 +29,10 @@ is_s3_instance <- function(value, class_name, allow_null = FALSE) {
 }
 assertthat::on_failure(is_s3_instance) <- function(call, env) {
   allow_null <- callget(call, env, "allow_null", FALSE)
-  msg <- paste0(
-    deparse(call$value),
-    " must be an instance of S3 class ",
-    call$class_name
-    )
 
   msg <- paste0(
-    msg,
+    deparse(call$value),
+    snippet_must_be(paste0("instance of S3 class ", call$class_name)),
     snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))

--- a/R/s4.R
+++ b/R/s4.R
@@ -40,14 +40,10 @@ is_s4_instance <- function(value, class_name, allow_null = FALSE) {
 
 assertthat::on_failure(is_s4_instance) <- function(call, env) {
   allow_null <- callget(call, env, "allow_null", FALSE)
-  msg <- paste0(
-    deparse(call$value),
-    " must be an instance of S4 class ",
-    call$class_name
-  )
 
   msg <- paste0(
-    msg,
+    deparse(call$value),
+    snippet_must_be(paste0("instance of S4 class ", call$class_name)),
     snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))

--- a/R/s4.R
+++ b/R/s4.R
@@ -46,12 +46,9 @@ assertthat::on_failure(is_s4_instance) <- function(call, env) {
     call$class_name
   )
 
-  if (allow_null) {
-    msg <- paste0(msg, " or NULL")
-  }
-
   msg <- paste0(
     msg,
+    snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))
   )

--- a/R/sets.R
+++ b/R/sets.R
@@ -33,17 +33,18 @@ is_one_of <- function(value, options, allow_null = FALSE) {
 }
 assertthat::on_failure(is_one_of) <- function(call, env) {
   allow_null <- callget(call, env, "allow_null", FALSE)
+  options <- callget(call, env, "options", NULL)
 
-  msg <- paste0(deparse(call$value), " must be one of the following: '",
-                paste0(
-                  eval(call$options, env),
-                  collapse = "', '"
-                  ),
-                "'",
-                snippet_null(allow_null),
-                ". Got: ",
-                deparse(eval(call$value, env))
-                )
+  msg <- paste0(
+    deparse(call$value),
+    snippet_must_be(
+      paste0("one of the following: ", flatten_vector(options)),
+      article = FALSE
+    ),
+    snippet_null(allow_null),
+    ". Got: ",
+    deparse(eval(call$value, env))
+  )
   return(msg)
 }
 
@@ -121,21 +122,17 @@ assertthat::on_failure(mutually_exclusive) <- function(call, env) {
   }
 
   if (length(not_null_idx) == 0 && !allow_all_null) {
-    msg <- paste0("'",
-      paste0(tail(args, -1), collapse = "', '"),
-      "' must be mutually exclusive", allow_all_null_msg, ". Got all NULLs"
+    msg <- paste0(
+      flatten_vector(tail(args, -1)),
+      " must be mutually exclusive", allow_all_null_msg, ". Got all NULLs"
     )
     return(msg)
   }
 
   msg <- paste0(
-    "'",
-    paste0(
-      args[not_null_idx],
-      collapse = "', '"
-      ),
-    "' must be mutually exclusive", allow_all_null_msg, ". Got ",
-    paste0(not_null_val[not_null_idx], collapse = ", ")
+    flatten_vector(args[not_null_idx]),
+    " must be mutually exclusive", allow_all_null_msg, ". Got ",
+    flatten_vector(not_null_val[not_null_idx])
     )
   return(msg)
 }

--- a/R/sets.R
+++ b/R/sets.R
@@ -16,7 +16,7 @@
 #'
 #' @concept set
 #' @export
-is_one_of <- function(value, options, allow_null = NULL) {
+is_one_of <- function(value, options, allow_null = FALSE) {
   if (is.null(value) && allow_null) {
     return(TRUE)
   }
@@ -32,19 +32,15 @@ is_one_of <- function(value, options, allow_null = NULL) {
   return(value %in% options)
 }
 assertthat::on_failure(is_one_of) <- function(call, env) {
-  allow_null_msg <- ""
-  if (!is.null(call$allow_null)) {
-    if (eval(call$allow_null, env)) {
-      allow_null_msg <- " or NULL"
-    }
-  }
+  allow_null <- callget(call, env, "allow_null", FALSE)
+
   msg <- paste0(deparse(call$value), " must be one of the following: '",
                 paste0(
                   eval(call$options, env),
                   collapse = "', '"
                   ),
                 "'",
-                allow_null_msg,
+                snippet_null(allow_null),
                 ". Got: ",
                 deparse(eval(call$value, env))
                 )

--- a/R/string.R
+++ b/R/string.R
@@ -43,20 +43,14 @@ is_string_value <- function(value, allow_empty = TRUE,
   return(TRUE)
 }
 assertthat::on_failure(is_string_value) <- function(call, env) {
-  non_empty_msg <- ""
-
   allow_empty <- callget(call, env, "allow_empty", TRUE)
   allow_na <- callget(call, env, "allow_na", FALSE)
   allow_null <- callget(call, env, "allow_null", FALSE)
-  if (!allow_empty) {
-    non_empty_msg <- " non-empty"
-  }
 
   msg <- paste0(
     deparse(call$value),
-    " must be a",
-    non_empty_msg,
-    " string",
+    snippet_must_be("string"),
+    snippet_not_empty(allow_empty),
     snippet_na(allow_na),
     snippet_null(allow_null),
     ". Got: ",
@@ -119,46 +113,18 @@ is_string_vector <- function(
   return(TRUE)
 }
 assertthat::on_failure(is_string_vector) <- function(call, env) {
-  msg <- paste0(deparse(call$value), " must be a string vector")
-
-  if (!is.null(call$exact_length)) {
-    msg <- paste0(
-      msg,
-      " of exact length ", eval(call$exact_length, env)
-    )
-  } else if (!is.null(call$min_length) && !is.null(call$max_length)) {
-    msg <- paste0(
-      msg,
-      " of length between ",
-      eval(call$min_length, env),
-      " and ",
-      eval(call$max_length, env),
-      " inclusive"
-    )
-  } else if (is.null(call$min_length) && !is.null(call$max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not greater than ",
-      eval(call$max_length, env)
-    )
-  } else if (!is.null(call$min_length) && is.null(call$max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not less than ",
-      eval(call$min_length, env)
-    )
-  }
-  if (is.null(call$allow_na_values) ||
-      eval(call$allow_na_values, env) == FALSE) {
-    msg <- paste0(msg, " with no NAs")
-  }
-
-  if (!is.null(call$allow_null) && eval(call$allow_null, env) == TRUE) {
-    msg <- paste0(msg, " or NULL")
-  }
+  exact_length <- callget(call, env, "exact_length", NULL)
+  min_length <- callget(call, env, "min_length", NULL)
+  max_length <- callget(call, env, "max_length", NULL)
+  allow_na_values <- callget(call, env, "allow_na_values", FALSE)
+  allow_null <- callget(call, env, "allow_null", FALSE)
 
   msg <- paste0(
-    msg,
+    deparse(call$value),
+    snippet_must_be("string vector"),
+    snippet_length(exact_length, min_length, max_length),
+    snippet_na_values(allow_na_values),
+    snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))
   )

--- a/R/string.R
+++ b/R/string.R
@@ -50,23 +50,13 @@ assertthat::on_failure(is_string_value) <- function(call, env) {
     non_empty_msg <- " non-empty"
   }
 
-  allow_na_msg <- ""
-  if (allow_na) {
-    allow_na_msg <- " or NA"
-  }
-
-  allow_null_msg <- ""
-  if (allow_null) {
-    allow_null_msg <- " or NULL"
-  }
-
   msg <- paste0(
     deparse(call$value),
     " must be a",
     non_empty_msg,
     " string",
-    allow_na_msg,
-    allow_null_msg,
+    snippet_na(allow_na),
+    snippet_null(allow_null),
     ". Got: ",
     deparse(eval(call$value, env))
     )

--- a/R/text_snippets.R
+++ b/R/text_snippets.R
@@ -14,3 +14,50 @@ snippet_na <- function(allow_na) {
   return(allow_na_msg)
 
 }
+
+snippet_length <- function(
+    exact_length = NULL, min_length = NULL, max_length = NULL
+  ) {
+  msg <- ""
+  if (!is.null(exact_length)) {
+    msg <- paste0(" of exact length ", exact_length)
+  } else if (!is.null(min_length) && !is.null(max_length)) {
+    msg <- paste0(
+      " of length between ", min_length, " and ", max_length, " inclusive"
+    )
+  } else if (is.null(min_length) && !is.null(max_length)) {
+    msg <- paste0(" of length not greater than ", max_length)
+  } else if (!is.null(min_length) && is.null(max_length)) {
+    msg <- paste0(" of length not less than ", min_length)
+  }
+
+  return(msg)
+}
+
+snippet_must_be <- function(type) {
+  return(paste0(" must be a ", type))
+}
+
+snippet_na_values <- function(allow_na_values) {
+  msg <- ""
+  if (!allow_na_values) {
+    msg <- paste0(" with no NA values")
+  }
+  return(msg)
+}
+
+snippet_exact_levels <- function(exact_levels) {
+  msg <- ""
+  if (!is.null(exact_levels)) {
+    msg <- paste0(" with exact levels ", flatten_vector(exact_levels))
+  }
+  return(msg)
+}
+
+flatten_vector <- function(vector) {
+  msg <- paste0(
+    "('", paste0(vector, collapse = "', '"), "')"
+  )
+
+  return(msg)
+}

--- a/R/text_snippets.R
+++ b/R/text_snippets.R
@@ -35,13 +35,18 @@ snippet_length <- function(
 }
 
 snippet_must_be <- function(type) {
-  return(paste0(" must be a ", type))
+
+  article <- "a"
+  if (substr(type, 1, 1) %in% c("a", "i", "e", "o", "u")) {
+    article <- "an"
+  }
+  return(paste0(" must be ", article, " ", type))
 }
 
 snippet_na_values <- function(allow_na_values) {
   msg <- ""
   if (!allow_na_values) {
-    msg <- paste0(" with no NA values")
+    msg <- paste0(" with no NAs")
   }
   return(msg)
 }
@@ -50,6 +55,41 @@ snippet_exact_levels <- function(exact_levels) {
   msg <- ""
   if (!is.null(exact_levels)) {
     msg <- paste0(" with exact levels ", flatten_vector(exact_levels))
+  }
+  return(msg)
+}
+
+snippet_numerical_range <- function(min = NULL, max = NULL) {
+  msg <- ""
+  if (!is.null(min) || !is.null(max)) {
+    msg <- " in the range "
+    if (is.null(min)) {
+      msg <- paste0(msg, "(-inf, ")
+    } else {
+      msg <- paste0(msg, "[", min, ", ")
+    }
+
+    if (is.null(max)) {
+      msg <- paste0(msg, "inf)")
+    } else {
+      msg <- paste0(msg, max, "]")
+    }
+  }
+  return(msg)
+}
+
+snippet_degenerate <- function(allow_degenerate) {
+  msg <- ""
+  if (!allow_degenerate) {
+    msg <- " non-degenerate"
+  }
+  return(msg)
+}
+
+snippet_names <- function(required_names = NULL) {
+  msg <- ""
+  if (!is.null(required_names)) {
+    msg <- paste0(" with at least names ", flatten_vector(required_names))
   }
   return(msg)
 }

--- a/R/text_snippets.R
+++ b/R/text_snippets.R
@@ -1,0 +1,16 @@
+snippet_null <- function(allow_null) {
+  allow_null_msg <- ""
+  if (allow_null) {
+    allow_null_msg <- " or NULL"
+  }
+  return(allow_null_msg)
+}
+
+snippet_na <- function(allow_na) {
+  allow_na_msg <- ""
+  if (allow_na) {
+    allow_na_msg <- " or NA"
+  }
+  return(allow_na_msg)
+
+}

--- a/R/value.R
+++ b/R/value.R
@@ -32,7 +32,7 @@ is_value <- function(value, allow_na = FALSE, allow_null = FALSE) {
 assertthat::on_failure(is_value) <- function(call, env) {
   msg <- paste0(
     deparse(call$value),
-    " must be a single value",
+    snippet_must_be("single value"),
     ". Got: ",
     deparse(eval(call$value, env)))
   return(msg)
@@ -62,7 +62,7 @@ is_na_value <- function(value) {
 assertthat::on_failure(is_na_value) <- function(call, env) {
   msg <- paste0(
     deparse(call$value),
-    " must be NA",
+    snippet_must_be("NA (any type)"),
     ". Got: ",
     deparse(eval(call$value, env)))
   return(msg)

--- a/R/vector.R
+++ b/R/vector.R
@@ -52,7 +52,7 @@ assertthat::on_failure(is_vector) <- function(call, env) {
 
   msg <- paste0(
     deparse(call$value),
-    " must be a vector",
+    snippet_must_be("vector"),
     snippet_length(exact_length, min_length, max_length),
     ". Got: ",
     deparse(eval(call$value, env))
@@ -172,13 +172,13 @@ vector_allowed_values <- function(v, allowed_values) {
   return(all(v %in% allowed_values))
 }
 assertthat::on_failure(vector_allowed_values) <- function(call, env) {
+  allowed_values <- callget(call, env, "allowed_values", NULL)
+
   return(paste0(
     deparse(call$v),
-    " must be a vector containing only elements from the following list: ",
-    paste0(
-      eval(call$allowed_values, env),
-      collapse = ", "
-    )
+    snippet_must_be("vector"),
+    " containing only elements from the following list: ",
+    flatten_vector(allowed_values)
   ))
 }
 
@@ -210,7 +210,10 @@ is_vector_without_na <- function(value) {
   return(TRUE)
 }
 assertthat::on_failure(is_vector_without_na) <- function(call, env) {
-  msg <- paste0(deparse(call$value), " must be a vector with no NA values.")
+  msg <- paste0(deparse(call$value),
+    snippet_must_be("vector with no NAs"),
+    "."
+  )
 
   return(msg)
 }
@@ -245,7 +248,8 @@ is_vector_all_na <- function(value) {
 assertthat::on_failure(is_vector_all_na) <- function(call, env) {
   msg <- paste0(
     deparse(call$value),
-    " must be a vector containing only NA values."
+    snippet_must_be("vector containing only NAs"),
+    "."
   )
 
   return(msg)
@@ -314,12 +318,6 @@ vector_value_occurrences <- function(
 
 }
 assertthat::on_failure(vector_value_occurrences) <- function(call, env) {
-  msg <- paste0(
-    deparse(call$vec),
-    " must be a vector containing value '",
-    eval(call$value, env),
-    "'"
-  )
 
   total_occurrences <- sum(
     eval(call$vec, env) == eval(call$value, env), na.rm = TRUE
@@ -328,47 +326,14 @@ assertthat::on_failure(vector_value_occurrences) <- function(call, env) {
   exact_occurrences <- callget(call, env, "exact_occurrences", NULL)
   min_occurrences <- callget(call, env, "min_occurrences", NULL)
   max_occurrences <- callget(call, env, "max_occurrences", NULL)
+  value <- callget(call, env, "value", NULL)
 
-  if (!is.null(exact_occurrences)) {
-    msg <- paste0(
-      msg,
-      " exactly ", exact_occurrences,
-      " times. Found it ",
-      total_occurrences,
-      " times."
-    )
-    return(msg)
-  }
-
-  if (!is.null(min_occurrences) && !is.null(max_occurrences)) {
-    msg <- paste0(
-      msg,
-      " between ",
-      min_occurrences,
-      " and ",
-      max_occurrences,
-      " times inclusive."
-    )
-  } else if (is.null(min_occurrences) && !is.null(max_occurrences)) {
-    msg <- paste0(
-      msg,
-      " no more than ",
-      max_occurrences,
-      " times inclusive."
-    )
-  } else if (!is.null(min_occurrences) && is.null(max_occurrences)) {
-    msg <- paste0(
-      msg,
-      " no less than ",
-      min_occurrences,
-      " times inclusive."
-    )
-  }
   msg <- paste0(
-    msg,
-    " Found it ",
-    total_occurrences,
-    " times."
+    deparse(call$vec),
+    snippet_must_be("vector"),
+    " containing value '", value, "'",
+    snippet_occurrences(exact_occurrences, min_occurrences, max_occurrences),
+    ". Found it ", total_occurrences, " times."
   )
   return(msg)
 }

--- a/R/vector.R
+++ b/R/vector.R
@@ -46,49 +46,18 @@ is_vector <- function(
   return(TRUE)
 }
 assertthat::on_failure(is_vector) <- function(call, env) {
-  msg <- paste0(deparse(call$value), " must be a vector")
   exact_length <- callget(call, env, "exact_length", NULL)
   min_length <- callget(call, env, "min_length", NULL)
   max_length <- callget(call, env, "max_length", NULL)
 
-  if (!is.null(exact_length)) {
-    msg <- paste0(
-      msg,
-      " of exact length ", exact_length,
-      ". Got: ",
-      deparse(eval(call$value, env))
-
-    )
-    return(msg)
-  }
-
-  if (!is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length between ",
-      min_length,
-      " and ",
-      max_length,
-      " inclusive"
-    )
-  } else if (is.null(min_length) && !is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not greater than ",
-      max_length
-    )
-  } else if (!is.null(min_length) && is.null(max_length)) {
-    msg <- paste0(
-      msg,
-      " of length not less than ",
-      min_length
-    )
-  }
   msg <- paste0(
-    msg,
+    deparse(call$value),
+    " must be a vector",
+    snippet_length(exact_length, min_length, max_length),
     ". Got: ",
     deparse(eval(call$value, env))
   )
+
   return(msg)
 }
 

--- a/tests/testthat/test_assert.R
+++ b/tests/testthat/test_assert.R
@@ -9,6 +9,6 @@ test_that("assert", {
   )
   expect_equal(
     as.character(err),
-    "Error: 3 must be a factor with exact levels ('bar', 'foo') with no NA values; or NULL. Got: 3\n"
+    "Error: 3 must be a factor with exact levels ('bar', 'foo') with no NAs; or NULL. Got: 3\n"
   )
 })

--- a/tests/testthat/test_assert.R
+++ b/tests/testthat/test_assert.R
@@ -9,6 +9,6 @@ test_that("assert", {
   )
   expect_equal(
     as.character(err),
-    "Error: 3 must be a factor with exact levels ('bar', 'foo') with no NAs; or NULL. Got: 3\n"
+    "Error: 3 must be a factor with exact levels ('bar', 'foo') with no NA values; or NULL. Got: 3\n"
   )
 })

--- a/tests/testthat/test_factor.R
+++ b/tests/testthat/test_factor.R
@@ -21,6 +21,6 @@ test_that("is_factor", {
   )
   expect_equal(
     as.character(err),
-    "Error: 3 must be a factor with exact levels ('bar', 'foo') with no NAs; or NULL. Got: 3\n"
+    "Error: 3 must be a factor with exact levels ('bar', 'foo') with no NA values; or NULL. Got: 3\n"
   )
 })

--- a/tests/testthat/test_factor.R
+++ b/tests/testthat/test_factor.R
@@ -21,6 +21,6 @@ test_that("is_factor", {
   )
   expect_equal(
     as.character(err),
-    "Error: 3 must be a factor with exact levels ('bar', 'foo') with no NA values; or NULL. Got: 3\n"
+    "Error: 3 must be a factor with exact levels ('bar', 'foo') with no NAs; or NULL. Got: 3\n"
   )
 })

--- a/tests/testthat/test_logical.R
+++ b/tests/testthat/test_logical.R
@@ -12,5 +12,5 @@ test_that("is_logical_value", {
 
   expect_equal(
     as.character(err),
-    "Error: foo must be a single logical value. Got: -1.5\n")
+    "Error: foo must be a logical value. Got: -1.5\n")
 })

--- a/tests/testthat/test_real.R
+++ b/tests/testthat/test_real.R
@@ -23,7 +23,7 @@ test_that("is_real_value", {
   )
   expect_equal(
     as.character(err),
-    "Error: foo must be a single real value. Got: \"hello\"\n")
+    "Error: foo must be a real value. Got: \"hello\"\n")
 })
 
 test_that("is_probability_value", {
@@ -48,7 +48,7 @@ test_that("is_probability_value", {
   )
   expect_equal(
     as.character(err),
-    "Error: foo must be a single probability value in the interval [0.0, 1.0]. Got: -0.3\n")
+    "Error: foo must be a probability value in the interval [0.0, 1.0]. Got: -0.3\n")
 })
 
 test_that("is_positive_real_value", {
@@ -139,7 +139,8 @@ test_that("is_binary_vector", {
   expect_equal(
     as.character(err),
     paste0(
-      "Error: v2 must be a vector of binary values (0 or 1) with no NAs\n"
+      "Error: v2 must be a vector of binary values (0 or 1) ",
+      "possibly degenerate with no NAs\n"
      ))
 })
 

--- a/tests/testthat/test_real.R
+++ b/tests/testthat/test_real.R
@@ -139,7 +139,7 @@ test_that("is_binary_vector", {
   expect_equal(
     as.character(err),
     paste0(
-      "Error: v2 must be a vector of binary values (0 or 1)\n"
+      "Error: v2 must be a vector of binary values (0 or 1) with no NAs\n"
      ))
 })
 
@@ -172,7 +172,8 @@ test_that("is_binary_vector allow_degenerate", {
   expect_equal(
     as.character(err),
     paste0(
-      "Error: v1 must be a non-degenerate vector of binary values (0 or 1)\n"
+      "Error: v1 must be a vector of binary values (0 or 1)",
+      " non-degenerate with no NAs\n"
      ))
 })
 

--- a/tests/testthat/test_sets.R
+++ b/tests/testthat/test_sets.R
@@ -101,7 +101,7 @@ test_that("is_one_of", {
   expect_equal(
     as.character(err),
     paste0(
-      "Error: val must be one of the following: 'foo', 'quux', 'NA' or NULL. ",
+      "Error: val must be one of the following: 'foo', 'quux', NA or NULL. ",
       "Got: \"x\"\n"
      ))
 })

--- a/tests/testthat/test_value.R
+++ b/tests/testthat/test_value.R
@@ -24,5 +24,5 @@ test_that("is_na_value", {
 
   expect_equal(
     as.character(err),
-    "Error: foo must be NA. Got: 3\n")
+    "Error: foo must be a NA (any type). Got: 3\n")
 })

--- a/tests/testthat/test_vector.R
+++ b/tests/testthat/test_vector.R
@@ -219,7 +219,7 @@ test_that("vector_allowed_values", {
     as.character(err),
     paste0(
       "Error: v1 must be a vector containing only elements from the ",
-      "following list: foo, quux, NA\n"
+      "following list: 'foo', 'quux', NA\n"
      ))
 })
 test_that("is_vector_without_na", {


### PR DESCRIPTION
Precursor to a major change where all checks will report the reason for the failure in a user friendly way, including solutions on how to fix the issue.
